### PR TITLE
Fix/network: Windows / Linux Network thread bugs compilation

### DIFF
--- a/blender/export.py
+++ b/blender/export.py
@@ -1,0 +1,78 @@
+import bpy
+import os
+import numpy as np
+from mathutils import Matrix, Vector, Euler
+import math
+from copy import deepcopy
+
+
+def origin_to_bottom(ob, matrix=Matrix()):
+    me = ob.data
+    mw = ob.matrix_world
+    local_verts = [matrix @ Vector(v[:]) for v in ob.bound_box]
+    o = sum(local_verts, Vector()) / 8
+    o.z = min(v.z for v in local_verts)
+    o = matrix.inverted() @ o
+    me.transform(Matrix.Translation(-o))
+    mw.translation = mw @ o
+
+def load_euler_angles(file_path):
+    try:
+        with open(file_path, 'r') as file:
+            # Read the first line and split by commas
+            line = file.readline().strip()
+            euler_values = [float(val) for val in line.split(' ')]
+
+            # Ensure the file has 3 values for the Euler angles (XYZ)
+            if len(euler_values) == 3:
+                return euler_values
+            else:
+                raise ValueError("The file should contain exactly 3 values for Euler angles.")
+    except Exception as e:
+        print(f"Error reading file: {e}")
+        return None
+
+output_directory = "/home/epitech/Documents/very_mdel_rtype/export-al/exported3/"
+
+if not os.path.exists(output_directory):
+    os.makedirs(output_directory)
+
+bpy.ops.object.select_all(action='DESELECT')
+already_seen = {}
+target_rotation = Euler((0, 0, 0))
+
+for collection in bpy.data.collections:
+    for object in collection.all_objects:
+        if (object.type != 'MESH'):
+            continue
+        if (object.name.isdigit()):
+            continue
+
+        splitted = object.name.split('.')
+        realname = splitted[0]
+
+        alreadyRegisterd = realname in already_seen.keys()
+
+        if alreadyRegisterd:
+            continue
+
+        object.select_set(True)
+        already_seen[realname] = object
+        obj_file_path = os.path.join(output_directory, f"{realname}.obj")
+        info_file = os.path.join(output_directory, f"{realname}.info")
+
+        origin_to_bottom(object)
+        # bpy.ops.object.origin_set(type='ORIGIN_CENTER_OF_VOLUME')
+        bpy.ops.object.location_clear(clear_delta=False)
+        ogAngle = load_euler_angles(info_file)
+        if (ogAngle == None):
+            object.select_set(False)
+            continue
+        object.rotation_mode = "ZXY"
+        object.rotation_euler = (math.radians(ogAngle[0]), math.radians(ogAngle[1]), math.radians(ogAngle[2]))
+
+        bpy.ops.wm.obj_export(filepath=obj_file_path, export_selected_objects=True, export_materials=True)
+        # bpy.ops.export_scene.gltf(filepath=obj_file_path, export_format='GLB', export_materials='EXPORT', use_selection=True)
+        object.select_set(False)
+
+print("Export completed. Check the log file for details.")

--- a/include/GEngine/interface/network/Replay.hpp
+++ b/include/GEngine/interface/network/Replay.hpp
@@ -6,7 +6,7 @@
 #include "GEngine/libdev/systems/MainLoop.hpp"
 #include "GEngine/libdev/systems/events/MainLoop.hpp"
 
-#include "GEngine/interface/network/systems/ClientServer.hpp"
+#include "GEngine/interface/network/systems/RecordManager.hpp"
 #include "GEngine/interface/network/systems/Updater.hpp"
 
 #include "GEngine/net/events/disconnection.hpp"
@@ -41,20 +41,13 @@ public:
         Network::NET::init();
         Network::NET::initClient();
 
-        Network::Event::Manager &em = Network::NET::getEventManager();
         m_local.registerSystem<gengine::interface::network::system::Updater>(m_local.getWorld());
-        m_local.registerSystem<gengine::interface::network::system::ClientServer>();
         Network::NET::start();
 
-        auto recordInfo = Network::Event::RecordInfo(Network::Event::RecordInfo::WATCH);
-        recordInfo.demoFile = demoPath;
-        size_t ticket = em.addEvent(Network::Event::RECORD, recordInfo);
-        auto result = em.getLastResult(ticket, true);
-        if (result != Network::Event::Result::OK)
-            throw std::runtime_error("Failed to start replay");
+        m_remote.registerSystem<gengine::system::AutoMainLoop>(60, 40);
+        m_local.registerSystem<gengine::system::AutoMainLoop>(60, 40);
 
-        m_remote.registerSystem<gengine::system::AutoMainLoop>();
-        m_local.registerSystem<gengine::system::AutoMainLoop>();
+        m_local.registerSystem<gengine::interface::network::system::RecordManager>();
     }
 
     ~Replay() {
@@ -63,6 +56,10 @@ public:
 
     void run() override {
         m_local.start();
+
+        auto e = gengine::interface::network::event::WatchReplay(m_demoPath);
+        m_local.publishEvent(e);
+
         m_local.compute();
     }
 

--- a/include/GEngine/interface/network/events/Record.hpp
+++ b/include/GEngine/interface/network/events/Record.hpp
@@ -13,8 +13,15 @@
 #include "GEngine/libdev/System.hpp"
 
 namespace gengine::interface::network::event {
-struct ToogleRecord : gengine::Event {
-    ToogleRecord() {
+struct ToggleRecord : gengine::Event {
+    ToggleRecord() {
     }
+};
+
+struct WatchReplay : gengine::Event {
+    WatchReplay(const std::string &demoPath)
+        : demoPath(demoPath) {
+    }
+    std::string demoPath;
 };
 } // namespace gengine::interface::network::event

--- a/include/GEngine/interface/network/systems/RecordManager.hpp
+++ b/include/GEngine/interface/network/systems/RecordManager.hpp
@@ -24,10 +24,11 @@ public:
     void init(void) override;
     void onGameLoop(gengine::system::event::GameLoop &);
 
-    void toggleCapture(gengine::interface::network::event::ToogleRecord &);
+    void toggleCapture(gengine::interface::network::event::ToggleRecord &);
+    void watchReplay(gengine::interface::network::event::WatchReplay &);
 
 private:
-    bool m_started = false;
+    static bool mg_started;
 };
 
 } // namespace gengine::interface::network::system

--- a/include/GEngine/interface/network/systems/RecordManager.hpp
+++ b/include/GEngine/interface/network/systems/RecordManager.hpp
@@ -13,8 +13,6 @@
 #include "GEngine/libdev/systems/events/GameLoop.hpp"
 #include "GEngine/libdev/systems/events/Native.hpp"
 
-#include "GEngine/libdev/systems/driver/input/KeyboardCatcher.hpp"
-
 #include "GEngine/interface/network/events/Record.hpp"
 
 namespace gengine::interface::network::system {

--- a/include/GEngine/interface/network/systems/VoIPManager.hpp
+++ b/include/GEngine/interface/network/systems/VoIPManager.hpp
@@ -28,10 +28,12 @@ class VoIPManager : public System<VoIPManager, interface::component::RemoteLocal
                     public RemoteSystem {
 
 public:
-    VoIPManager(float distance = 0);
+    VoIPManager(float distance = UNDEFINED_DISTANCE);
     void init(void) override;
 
 private:
+    static constexpr float UNDEFINED_DISTANCE = 0;
+
     float m_distance;
     float calculateDistance(uuids::uuid c1, uuids::uuid c2);
     void onMainLoop(gengine::system::event::MainLoop &);

--- a/include/GEngine/libdev/systems/driver/input/VoIPAudioCatcher.hpp
+++ b/include/GEngine/libdev/systems/driver/input/VoIPAudioCatcher.hpp
@@ -28,6 +28,7 @@ public:
     void init(void) override;
 
     void onMainLoop(gengine::system::event::MainLoop &e);
+    void onStartEngine(gengine::system::event::StartEngine &e);
     void onStartVoIP(gengine::system::event::driver::input::StartVoIP &);
     void onEndVoIP(gengine::system::event::driver::input::EndVoIP &);
 

--- a/include/GEngine/libdev/systems/driver/output/VoIPAudio.hpp
+++ b/include/GEngine/libdev/systems/driver/output/VoIPAudio.hpp
@@ -29,6 +29,7 @@ public:
     ~VoIPAudio() override;
 
     void onMainLoop(gengine::system::event::MainLoop &e);
+    void onStartEngine(gengine::system::event::StartEngine &e);
 
     void init(void) override;
 

--- a/include/GEngine/net/cl_net_client.hpp
+++ b/include/GEngine/net/cl_net_client.hpp
@@ -250,7 +250,7 @@ private:
     /* todo : change based on average size */
     NetQueue<UDPMessage, 2, 1400> m_packOutData;    /* todo : get the size of Usercmd + own voip / */
     NetQueue<UDPMessage, 32, 1400> m_packInData;    /* voiceip etc.. */
-    NetQueue<UDPMessage, 2, 17000> m_packInDataAck; /* snapshot */
+    NetQueue<UDPMessage, 20, 17000> m_packInDataAck; /* snapshot */
 
     NetQueueHeap<TCPMessage, 5> m_tcpIn;
     NetQueueHeap<TCPMessage, 5> m_tcpOut;

--- a/include/GEngine/net/cl_net_client.hpp
+++ b/include/GEngine/net/cl_net_client.hpp
@@ -248,8 +248,8 @@ private:
     connectionState m_connectionState = CON_UNINITIALIZED;
 
     /* todo : change based on average size */
-    NetQueue<UDPMessage, 2, 1400> m_packOutData;    /* todo : get the size of Usercmd + own voip / */
-    NetQueue<UDPMessage, 32, 1400> m_packInData;    /* voiceip etc.. */
+    NetQueue<UDPMessage, 2, 1400> m_packOutData;     /* todo : get the size of Usercmd + own voip / */
+    NetQueue<UDPMessage, 32, 1400> m_packInData;     /* voiceip etc.. */
     NetQueue<UDPMessage, 20, 17000> m_packInDataAck; /* snapshot */
 
     NetQueueHeap<TCPMessage, 5> m_tcpIn;

--- a/include/GEngine/net/msg.hpp
+++ b/include/GEngine/net/msg.hpp
@@ -287,7 +287,7 @@ public:
         if (!isCompressed())
             throw MsgError("Message is not compressed");
 
-        if (m_curSize + offset + getBitBuffer() / 8 > getMaxMsgSize()) {
+        if (offset + getBitBuffer() / 8 > getMaxMsgSize()) {
             throw MsgError("Message overflow when reading: SIZE=" +
                            std::to_string(m_curSize + offset + getBitBuffer() / 8));
         }

--- a/include/GEngine/net/net_client.hpp
+++ b/include/GEngine/net/net_client.hpp
@@ -125,8 +125,8 @@ public:
     bool pushStream(const TCPMessage &msg);
     bool popIncommingData(UDPMessage &msg, size_t &readCount);
     bool popIncommingStream(TCPMessage &msg, size_t &readCount);
-    size_t getSizeIncommingData(void) const {
-        return m_packInData.size();
+    size_t getSizeIncommingData(uint8_t type) const {
+        return m_packInData.size(type);
     }
 
     /**

--- a/include/GEngine/net/net_client.hpp
+++ b/include/GEngine/net/net_client.hpp
@@ -46,16 +46,6 @@ private:
     bool transmitHighFreqData; /* voip, webcam feed etc...*/
 };
 
-/* Since the engine and the snapshots are not defined in advance, we store them in heap with a predefined size */
-class NetClientSnapshot {
-public:
-    NetClientSnapshot(size_t size);
-    ~NetClientSnapshot() = default;
-
-private:
-    std::vector<byte_t> m_data;
-};
-
 /**
  * @class NetClient
  * @brief Manages network client operations including sending and receiving data over TCP and UDP.

--- a/include/GEngine/net/net_record.hpp
+++ b/include/GEngine/net/net_record.hpp
@@ -50,7 +50,7 @@ public:
 
     /* force the server to send fullsnapshot */
     bool startRecord(void);
-    bool endRecord(void);
+    bool endRecord(bool isDestructing = false);
 
     bool startWatch(const std::string &filePath);
     bool endWatch(bool wanted);
@@ -76,6 +76,8 @@ private:
     bool read(SerializedMessage &msg, uint8_t &type, uint32_t &sleepDuration);
 
     void openFile(const std::string &filename, bool checkHash = false);
+
+    void compressFile(void);
 
 private:
     std::fstream m_fs;

--- a/source/GEngine/interface/network/systems/CommandManager.cpp
+++ b/source/GEngine/interface/network/systems/CommandManager.cpp
@@ -220,6 +220,7 @@ void CLCommandManager::onGameLoop(gengine::system::event::GameLoop &e) {
         return;
 
     Network::TCPSV_CVar cvar;
+    std::memset(&cvar, 0, sizeof(cvar));
     recvMsg.readData((void *)(&cvar), readCount, recvMsg.getSize());
 
     if (cvar.result == NOT_FOUND)

--- a/source/GEngine/interface/network/systems/Updater.cpp
+++ b/source/GEngine/interface/network/systems/Updater.cpp
@@ -32,7 +32,7 @@ void Updater::onGameLoop(gengine::system::event::GameLoop &e) {
         Network::UDPMessage msg(Network::UDPMessage::HEADER, Network::SV_SNAPSHOT);
         size_t readCount;
         if (!cl.popIncommingData(msg, readCount, true))
-            continue;
+            break;
         handleSnapshotMsg(msg, readCount);
     }
 

--- a/source/GEngine/interface/network/systems/VoIPManager.cpp
+++ b/source/GEngine/interface/network/systems/VoIPManager.cpp
@@ -66,13 +66,15 @@ void VoIPManager::onMainLoop(gengine::system::event::MainLoop &) {
                 continue;
 
             // Calculer la distance entre le client source et le client destination
-            float distance = calculateDistance(remote, remoteDest);
+            float distance;
+            if (m_distance != UNDEFINED_DISTANCE)
+                distance = calculateDistance(remote, remoteDest);
             // float volume = 1.0f / (1.0f + distance); // Exemple de calcul du volume
             // Préparer le segment VoIP avec le volume
             Network::UDPG_VoIPSegment segment = {
                 .size = static_cast<uint16_t>(buffer.size()),
                 .volume =
-                    static_cast<float>(m_distance ? std::clamp(m_distance - distance, 0.f, m_distance) / m_distance
+                    static_cast<float>(m_distance != UNDEFINED_DISTANCE ? std::clamp(m_distance - distance, 0.f, m_distance) / m_distance
                                                   : 1) // Ajouter le volume au segment
             };
             std::memcpy(&segment.playerIndex1, remote.as_bytes().data(), 8);

--- a/source/GEngine/interface/network/systems/VoIPManager.cpp
+++ b/source/GEngine/interface/network/systems/VoIPManager.cpp
@@ -73,9 +73,9 @@ void VoIPManager::onMainLoop(gengine::system::event::MainLoop &) {
             // Préparer le segment VoIP avec le volume
             Network::UDPG_VoIPSegment segment = {
                 .size = static_cast<uint16_t>(buffer.size()),
-                .volume =
-                    static_cast<float>(m_distance != UNDEFINED_DISTANCE ? std::clamp(m_distance - distance, 0.f, m_distance) / m_distance
-                                                  : 1) // Ajouter le volume au segment
+                .volume = static_cast<float>(m_distance != UNDEFINED_DISTANCE
+                                                 ? std::clamp(m_distance - distance, 0.f, m_distance) / m_distance
+                                                 : 1) // Ajouter le volume au segment
             };
             std::memcpy(&segment.playerIndex1, remote.as_bytes().data(), 8);
             std::memcpy(&segment.playerIndex2, remote.as_bytes().data() + 8, 8);

--- a/source/GEngine/libdev/systems/driver/input/VoIPAudioCatcher.cpp
+++ b/source/GEngine/libdev/systems/driver/input/VoIPAudioCatcher.cpp
@@ -52,7 +52,10 @@ void VoIPAudioCatcher::init(void) {
     subscribeToEvent<gengine::system::event::driver::input::StartVoIP>(&VoIPAudioCatcher::onStartVoIP);
     subscribeToEvent<gengine::system::event::driver::input::EndVoIP>(&VoIPAudioCatcher::onEndVoIP);
     subscribeToEvent<gengine::system::event::MainLoop>(&VoIPAudioCatcher::onMainLoop);
+    subscribeToEvent<gengine::system::event::StartEngine>(&VoIPAudioCatcher::onStartEngine);
+}
 
+void VoIPAudioCatcher::onStartEngine(gengine::system::event::StartEngine &) {
     /** Port Audio + Opus **/
     int iErr;
     PaError paErr;

--- a/source/GEngine/libdev/systems/driver/output/AudioManager.cpp
+++ b/source/GEngine/libdev/systems/driver/output/AudioManager.cpp
@@ -83,6 +83,7 @@ void AudioManager::onMainLoop(geg::event::RenderLoop &e) {
             playSoundById(sound.soundId);
         }
         publishEvent(gengine::system::event::driver::output::SoundPlayed(sound.soundId));
+        killEntity(e);
     }
     for (auto it = m_soundsPlayed.begin(); it != m_soundsPlayed.end();)
         if (!sounds.contains(*it))

--- a/source/GEngine/libdev/systems/driver/output/VoIPAudio.cpp
+++ b/source/GEngine/libdev/systems/driver/output/VoIPAudio.cpp
@@ -77,6 +77,10 @@ static int playbackCallback(const void *inputBuffer, void *outputBuffer, unsigne
 
 void VoIPAudio::init(void) {
     subscribeToEvent<gengine::system::event::MainLoop>(&VoIPAudio::onMainLoop);
+    subscribeToEvent<gengine::system::event::StartEngine>(&VoIPAudio::onStartEngine);
+}
+
+void VoIPAudio::onStartEngine(gengine::system::event::StartEngine &) {
 
     /** Port Audio + Opus **/
 

--- a/source/GEngine/net/cl_net_client.cpp
+++ b/source/GEngine/net/cl_net_client.cpp
@@ -90,6 +90,8 @@ bool CLNetClient::handleUDPEvents(SocketUDP &socket, UDPMessage &msg, const Addr
         return false;
 
     switch (msg.getType()) {
+    case CL_BROADCAST_PING:
+        return true;
     case SV_BROADCAST_PING:
         getPingResponse(msg, addr);
         return true;

--- a/source/GEngine/net/msg/msg.cpp
+++ b/source/GEngine/net/msg/msg.cpp
@@ -65,7 +65,7 @@ void AMessage::readDataCompressed(void *data, size_t &offset, std::size_t size) 
     if (!isCompressed())
         throw MsgError("Message should be compressed");
 
-    if (m_curSize + offset + getBitBuffer() / 8 > getMaxMsgSize())
+    if (offset + getBitBuffer() / 8 > getMaxMsgSize())
         throw MsgError("Message overflow when reading: SIZE=" +
                        std::to_string(m_curSize + offset + getBitBuffer() / 8));
     m_huffman.decompressContinuous(*this, offset, (byte_t *)data, size);

--- a/source/GEngine/net/net_channel.cpp
+++ b/source/GEngine/net/net_channel.cpp
@@ -247,10 +247,8 @@ bool NetChannel::readStream(TCPMessage &msg) {
         m_tcpSocket.receive(msg, m_tcpBuffer, m_sizeBuffer);
     } catch (const SocketException &e) {
         if (dynamic_cast<const SocketDisconnected *>(&e) == nullptr) {
-            if (e.getCode() == WSAEWOULDBLOCK || e.getCode() == WSATRY_AGAIN) {
-                std::cout << "blocking" << std::endl;
+            if (e.getCode() == WSAEWOULDBLOCK || e.getCode() == WSATRY_AGAIN)
                 return false;
-            }
             std::cerr << "Socket exception: " << e.what() << std::endl;
         }
         m_disconnect = true;

--- a/source/GEngine/net/net_channel.cpp
+++ b/source/GEngine/net/net_channel.cpp
@@ -161,7 +161,7 @@ bool NetChannel::readDatagram(SocketUDP &socket, UDPMessage &msg, size_t &readOf
         m_udpACKClientLastACK = header.ack;
         m_droppedPackets = header.sequence - udpInSequence + 1;
 
-        if (msg.isFullAck())
+        if (!m_reloadingAck && msg.isFullAck())
             m_reloadingAck = false;
 
         /* todo : if > m_udpACKOutSequence, disconnect client since manipulating packets */

--- a/source/GEngine/net/net_channel.cpp
+++ b/source/GEngine/net/net_channel.cpp
@@ -161,7 +161,7 @@ bool NetChannel::readDatagram(SocketUDP &socket, UDPMessage &msg, size_t &readOf
         m_udpACKClientLastACK = header.ack;
         m_droppedPackets = header.sequence - udpInSequence + 1;
 
-        if (!m_reloadingAck && msg.isFullAck())
+        if (m_reloadingAck && msg.isFullAck())
             m_reloadingAck = false;
 
         /* todo : if > m_udpACKOutSequence, disconnect client since manipulating packets */

--- a/source/GEngine/net/net_huffman.cpp
+++ b/source/GEngine/net/net_huffman.cpp
@@ -55,7 +55,7 @@ size_t AHC::compressContinuous(AMessage &msg, size_t offset, const byte_t *pushD
 
 size_t AHC::decompressContinuous(AMessage &msg, size_t offset, byte_t *pushData, size_t size) {
     auto offsetBits = msg.getBitBuffer();
-    const size_t msgSize = msg.getMaxMsgSize() - offset - offsetBits / 8;
+    const size_t msgSize = msg.getMaxMsgSize() - offset;
     size_t old = msg.getBitBuffer();
 
     if (!m_decompress.readSymbol(msg.getData() + offset, pushData, size, msgSize, msg.getBitBuffer()))

--- a/source/GEngine/net/net_record.cpp
+++ b/source/GEngine/net/net_record.cpp
@@ -316,6 +316,9 @@ bool NetRecord::endWatch(bool wanted) {
     if (!isWatching())
         return false;
 
+    if (m_fs.is_open())
+        m_fs.close();
+
     m_watching = false;
     std::cout << "Demo ended." << std::endl;
     if (std::remove(m_decompressFilePath.c_str()) != 0)

--- a/source/GEngine/net/net_record.cpp
+++ b/source/GEngine/net/net_record.cpp
@@ -27,10 +27,15 @@ void NetRecord::init(void) {
 #else
     std::ifstream execFile("/proc/self/exe", std::ios::binary);
 #endif
+
+#if 0
     if (!execFile.is_open())
         throw NetException("Failed to open executable file for hashing", EL_ERR_RECORDING);
     std::vector<char> execBuffer((std::istreambuf_iterator<char>(execFile)), std::istreambuf_iterator<char>());
     m_execHash = std::hash<std::string>{}(std::string(execBuffer.begin(), execBuffer.end()));
+#else
+    m_execHash = 0;
+#endif
 
 #ifdef _WIN32
     m_recordFilePath = "C:\\Windows\\Temp\\record.bin";

--- a/source/GEngine/net/net_server.cpp
+++ b/source/GEngine/net/net_server.cpp
@@ -185,7 +185,7 @@ void NetServer::checkTimeouts(void) {
         return;
 
     for (const auto &client : m_clients) {
-        if (!client->isTimeout())
+        if (client.get() == nullptr || !client->isTimeout())
             continue;
 
         std::cout << "SV: Client timeout" << std::endl;

--- a/source/GEngine/net/net_socket.cpp
+++ b/source/GEngine/net/net_socket.cpp
@@ -16,9 +16,6 @@
 #include <stdexcept>
 #include <string>
 
-// temp
-#include <iostream>
-
 #ifdef _WIN32
 
 #else

--- a/source/GEngine/net/net_wait.cpp
+++ b/source/GEngine/net/net_wait.cpp
@@ -67,10 +67,10 @@ void NetWaitSet::reset(void) {
 
 #ifdef NET_USE_HANDLE
 bool NetWaitSet::applyCallback(void) const {
-    auto callbackRes = m_callbacks[m_resIndex]();
     BOOL res = WSAResetEvent(m_events[m_resIndex - WSA_WAIT_EVENT_0]);
     if (!res)
         wprintf(L"WSAResetEvent failed with error = %d\n", WSAGetLastError());
+    auto callbackRes = m_callbacks[m_resIndex]();
     return callbackRes;
 }
 #endif


### PR DESCRIPTION
- ACK Accumulation du retard en localhost
- Replay qui démarrait avant l'ecs
- Distance voip qui malgré son fix, windows crashait quand même
- Bug du 21000 décompression (my bad)
- Sound Event qui restait dans le ClientEventHandler, qui faisait qu'on ne pouvait plus tirer car y avait trop d'events (> 20)
- Windows: certains reset de socket rendait la socket complètement inutilisable
